### PR TITLE
Fix URL validation and add i18n fallbacks

### DIFF
--- a/scripts/copyKatex.js
+++ b/scripts/copyKatex.js
@@ -63,7 +63,7 @@ async function handleKatexClick(e) {
             await navigator.clipboard.writeText(textToCopy);
 
             // Show visual feedback with localized message using the toast notification
-            window.showToastNotification(chrome.i18n?.getMessage('formulaCopied'), 'success');
+            window.showToastNotification(chrome.i18n?.getMessage('formulaCopied') || 'Formula copied!', 'success');
         } catch (error) {
             console.error('Failed to copy formula:', error);
             window.showToastNotification(chrome.i18n?.getMessage('copyFailed'), 'error');

--- a/scripts/docxConverter.js
+++ b/scripts/docxConverter.js
@@ -456,6 +456,8 @@ function isValidUrl(string) {
     if (!string) return false;
     try {
         const url = new URL(string.trim());
+        // Localhost support for testing
+        if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') return true;
         return url.protocol === 'http:' || url.protocol === 'https:';
     } catch (_) {
         return false;


### PR DESCRIPTION
## Changes made:
1. Improved URL validation in `docxConverter.js` to support localhost for development
2. Added fallback text for missing i18n messages in `copyKatex.js`

## Why:
- Developers can now test with localhost URLs
- Prevents empty toast notifications when i18n messages are missing

## Testing:
- ✅ URL validator accepts http://localhost:3000
- ✅ Formula copy shows "Formula copied!" as fallback